### PR TITLE
Change title to show which full node is running in each console window

### DIFF
--- a/src/Stratis.CirrusD/Program.cs
+++ b/src/Stratis.CirrusD/Program.cs
@@ -35,6 +35,8 @@ namespace Stratis.CirrusD
         {
             try
             {
+                // set the console window title to identify this as a Cirrus full node (for clarity when running Strax and Cirrus on the same machine)
+				Console.Title = "Cirrus full node";
                 var nodeSettings = new NodeSettings(networksSelector: CirrusNetwork.NetworksSelector, protocolVersion: ProtocolVersion.CIRRUS_VERSION, args: args)
                 {
                     MinProtocolVersion = ProtocolVersion.ALT_PROTOCOL_VERSION

--- a/src/Stratis.CirrusD/Program.cs
+++ b/src/Stratis.CirrusD/Program.cs
@@ -36,7 +36,7 @@ namespace Stratis.CirrusD
             try
             {
                 // set the console window title to identify this as a Cirrus full node (for clarity when running Strax and Cirrus on the same machine)
-				Console.Title = "Cirrus full node";
+                Console.Title = "Cirrus full node";
                 var nodeSettings = new NodeSettings(networksSelector: CirrusNetwork.NetworksSelector, protocolVersion: ProtocolVersion.CIRRUS_VERSION, args: args)
                 {
                     MinProtocolVersion = ProtocolVersion.ALT_PROTOCOL_VERSION

--- a/src/Stratis.StraxD/Program.cs
+++ b/src/Stratis.StraxD/Program.cs
@@ -27,6 +27,8 @@ namespace Stratis.StraxD
         {
             try
             {
+                // set the console window title to identify this as a Strax full node (for clarity when running Strax and Cirrus on the same machine)
+				Console.Title = "Strax full node";
                 var nodeSettings = new NodeSettings(networksSelector: Networks.Strax, protocolVersion: ProtocolVersion.PROVEN_HEADER_VERSION, args: args)
                 {
                     MinProtocolVersion = ProtocolVersion.PROVEN_HEADER_VERSION

--- a/src/Stratis.StraxD/Program.cs
+++ b/src/Stratis.StraxD/Program.cs
@@ -28,7 +28,7 @@ namespace Stratis.StraxD
             try
             {
                 // set the console window title to identify this as a Strax full node (for clarity when running Strax and Cirrus on the same machine)
-				Console.Title = "Strax full node";
+                Console.Title = "Strax full node";
                 var nodeSettings = new NodeSettings(networksSelector: Networks.Strax, protocolVersion: ProtocolVersion.PROVEN_HEADER_VERSION, args: args)
                 {
                     MinProtocolVersion = ProtocolVersion.PROVEN_HEADER_VERSION


### PR DESCRIPTION
Added a line to the node start up to set the console window title to identify this which full node this is (for clarity when running Strax and Cirrus on the same machine)